### PR TITLE
RENS Bug fixes

### DIFF
--- a/ns_run.py
+++ b/ns_run.py
@@ -4065,7 +4065,11 @@ def main():
             outfile_dir = f"output_data_{replica_idx}/"
             ns_args['out_file_prefix'] = outfile_dir + ns_args['out_file_prefix']
             if rank == 0:
-                os.mkdir(outfile_dir)
+                if not os.path.exists(outfile_dir):
+                    os.mkdir(outfile_dir)
+                else:
+                    outfile.print(f"Detected Directory {outfile_dir}")
+                    
         
         ns_args['RE_n_swap_cycles'] = int(args.pop('RE_n_swap_cycles', 10))
         ns_args['RE_swap_interval'] = int(args.pop('RE_swap_interval', 5))

--- a/ns_run.py
+++ b/ns_run.py
@@ -3336,6 +3336,9 @@ def do_ns_loop(
                         ) 
                         if acc:
                             walker_rcv.info["ns_energy"] = h0
+                            #Without a deepcopy, the calculator object is lost, deepcopy not worth it
+                            if do_calc_ASE or do_calc_lammps:
+                                walker_rcv.calc = pot
                             walkers[swap_idx_phase1] = walker_rcv
 
                 if replica_idx % 2 != 0:
@@ -3367,6 +3370,9 @@ def do_ns_loop(
                     ) 
                     if acc:
                         walker_rcv.info["ns_energy"] = h1
+                        #Without a deepcopy, the calculator object is lost, deepcopy not worth it
+                        if do_calc_ASE or do_calc_lammps:
+                            walker_rcv.calc = pot
                         walkers[swap_idx_phase1] = walker_rcv
                     
                     # set acc to zero again, such that only the acc from the 
@@ -3449,6 +3455,9 @@ def do_ns_loop(
                             ) 
                             if acc:
                                 walker_rcv.info["ns_energy"] = h0
+                                #Without a deepcopy, the calculator object is lost, deepcopy not worth it
+                                if do_calc_ASE or do_calc_lammps:
+                                    walker_rcv.calc = pot
                                 walkers[swap_idx_phase2] = walker_rcv
 
                     if replica_idx % 2 == 0:
@@ -3480,6 +3489,9 @@ def do_ns_loop(
                             ) 
                             if acc:
                                 walker_rcv.info["ns_energy"] = h1
+                                #Without a deepcopy, the calculator object is lost, deepcopy not worth it
+                                if do_calc_ASE or do_calc_lammps:
+                                    walker_rcv.calc = pot
                                 walkers[swap_idx_phase2] = walker_rcv
 
                             acc = 0

--- a/ns_run.py
+++ b/ns_run.py
@@ -2595,7 +2595,7 @@ def do_ns_loop(
             outfile.print("WARNING: Emax not decreasing ", Emax_of_step, Emax_next)
         Emax_of_step = Emax_next
 
-        if ns_args['min_Emax'] is not None:
+        if ns_args['min_Emax'] is not None and i_ns_step%1000 == 0:
             break_loop = False
             if Emax_of_step < ns_args['min_Emax']:
                 if not doing_replica_exchange:
@@ -3300,8 +3300,8 @@ def do_ns_loop(
                 status = MPI.Status()
                 # swap_idx = np.random.randint(0, walkers_per_task)
                 # swap_idx_phase1 = 0
-                swap_idx_phase1 = rng.int_uniform(0, size_replica)
-
+                swap_idx_phase1 = rng.int_uniform(0, len(walkers))
+                
                 n_send = re_utils.get_buffer_size(
                     n_atoms,
                     do_velocities,
@@ -3431,7 +3431,7 @@ def do_ns_loop(
                     rcv_buf = np.zeros(n_send)
                     # swap_idx = np.random.randint(0, walkers_per_task)
                     # swap_idx_phase2 = 0
-                    swap_idx_phase2 = rng.int_uniform(0, size_replica)
+                    swap_idx_phase2 = rng.int_uniform(0, len(walkers))
                     walker_snd = walkers[swap_idx_phase2]
                     snd_buf = re_utils.construct_snd_buf(
                         walker_snd,


### PR DESCRIPTION
Fixed small bug with the lammps and ase calculator where the calculator gets lost after the replicas are exchanged.
Fixed a bug where the rng index was out of range when exchanging.

When starting from a restart you need to make False the make_output_dir, I just check if it exists instead of changing the input file for a restart.

I made the temperature stopping criteria wait until all the replicas have reached the temperature before breaking the ns loop. As opposed to one run breaking while the others proceed.